### PR TITLE
Add CMSeq version flag for each subcommand

### DIFF
--- a/.github/workflows/cmseq_ci.yml
+++ b/.github/workflows/cmseq_ci.yml
@@ -1,0 +1,39 @@
+name: CMSeq_ci
+
+on: [push,  pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      # - name: Lint with flake8
+      #   run: |
+      #     # stop the build if there are Python syntax errors or undefined names
+      #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+      #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Install CMSeq
+        run: |
+          pip install .
+      - name: Check cmseq help message
+        run: |
+          breadth_depth.py --help
+          consensus_aDNA.py --help
+          consensus.py --help
+          poly.py --help
+          polymut.py --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/cmseq/__init__.py
+++ b/cmseq/__init__.py
@@ -1,3 +1,5 @@
-from .cmseq import CMSEQ_DEFAULTS
-from .cmseq import BamFile
-from .cmseq import BamContig
+from cmseq.cmseq import CMSEQ_DEFAULTS
+from cmseq.cmseq import BamFile
+from cmseq.cmseq import BamContig
+
+__version__ = '1.0.4'

--- a/cmseq/breadth_depth.py
+++ b/cmseq/breadth_depth.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
-from .cmseq import CMSEQ_DEFAULTS
-from .cmseq import BamFile
+from cmseq.cmseq import CMSEQ_DEFAULTS
+from cmseq.cmseq import BamFile
+from cmseq import __version__
 
 import pandas as pd
 import numpy as np
@@ -11,6 +12,7 @@ import argparse
 
 def bd_from_file():
 	parser = argparse.ArgumentParser(description="calculate the Breadth and Depth of coverage of BAMFILE.")
+	parser.add_argument('--version', action='version', version=f"CMSeq {__version__}")
 
 	parser.add_argument('BAMFILE', help='The file on which to operate')
 	parser.add_argument('-c','--contig', help='Focus on a subset of references in the BAM file. Can be a list of references separated by commas or a FASTA file (the IDs are used to subset)', metavar="REFERENCE ID" ,default=None)

--- a/cmseq/cmseq.py
+++ b/cmseq/cmseq.py
@@ -9,10 +9,6 @@ from scipy import stats
 from collections import defaultdict
 import pickle,os
 
-__author__ = 'Moreno Zolfo (moreno.zolfo@unitn.it), Nicolai Karcher (nicolai.karcher@unitn.it), Kun Huang (kun.huang@unitn.it)'
-__version__ = '1.0.3'
-__date__ = '23 September 2020'
-
 def _initt(terminating_,_consensus_bamFile,_consensus_args):
 	global terminating
 	global consensus_args

--- a/cmseq/consensus.py
+++ b/cmseq/consensus.py
@@ -2,6 +2,8 @@ import pandas as pd
 import numpy as np
 import argparse
 import sys
+from cmseq import __version__
+
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -11,6 +13,8 @@ from .cmseq import BamFile
 
 def consensus_from_file():
 	parser = argparse.ArgumentParser(description="outputs the consensus in FASTA format. Non covered positions (or quality-trimmed positions) are reported as a dashes: -")
+	parser.add_argument('--version', action='version', version=f"CMSeq {__version__}")
+
 	parser.add_argument('BAMFILE', help='The file on which to operate')
 	parser.add_argument('-c','--contig', help='Focus on a subset of references in the BAM file. Can be a list of references separated by commas or a FASTA file (the IDs are used to subset)', metavar="REFERENCE ID" ,default=None)
 	parser.add_argument('-f', help='If set unmapped (FUNMAP), secondary (FSECONDARY), qc-fail (FQCFAIL) and duplicate (FDUP) are excluded. If unset ALL reads are considered (bedtools genomecov style). Default: unset',action='store_true')

--- a/cmseq/consensus_aDNA.py
+++ b/cmseq/consensus_aDNA.py
@@ -1,6 +1,8 @@
 from .cmseq import CMSEQ_DEFAULTS
 from .cmseq import BamFile
 from .cmseq import BamContig
+from cmseq import __version__
+
 import os
 import pysam
 import math
@@ -19,7 +21,6 @@ from Bio.SeqRecord import SeqRecord
 
 
 __author__ = 'Kun D. Huang (kun.huang@unitn.it), Moreno Zolfo (moreno.zolfo@unitn.it)'
-__version__ = '1.0.3'
 __date__ = '09 September 2020'
 
 class CMSEQ_DEFAULTS_Ancient(CMSEQ_DEFAULTS):
@@ -213,6 +214,8 @@ class BamContigAncient(BamContig):
 def consensus_from_file():
 
 	parser = argparse.ArgumentParser(description="outputs the consensus in FASTA format. Non covered positions (or quality-trimmed positions) are reported as a dashes: -")
+	parser.add_argument('--version', action='version', version=f"CMSeq {__version__}")
+
 	parser.add_argument('BAMFILE', help='The file on which to operate')
 	parser.add_argument('-c','--contig', help='Focus on a subset of references in the BAM file. Can be a list of references separated by commas or a FASTA file (the IDs are used to subset)', metavar="REFERENCE ID" ,default=None)
 	parser.add_argument('-f', help='If set unmapped (FUNMAP), secondary (FSECONDARY), qc-fail (FQCFAIL) and duplicate (FDUP) are excluded. If unset ALL reads are considered (bedtools genomecov style). Default: unset',action='store_true')

--- a/cmseq/filter.py
+++ b/cmseq/filter.py
@@ -2,8 +2,10 @@
 import pysam,sys
 import argparse
 import numpy as np
+from cmseq import __version__
 
 parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version', version=f"CMSeq {__version__}")
 
 parser.add_argument('--minlen', help='Minimum length of alignment for a read to pass', type=int, default=70)
 parser.add_argument('--minqual', help='Minimum average quality for a read to pass. It is computed over the fastq Phred-scores of each read', type=int, default=30)

--- a/cmseq/poly.py
+++ b/cmseq/poly.py
@@ -2,12 +2,15 @@ import pandas as pd
 import numpy as np
 import argparse
 import sys
+from cmseq import __version__
 
 from .cmseq import CMSEQ_DEFAULTS
 from .cmseq import BamFile
 
 def poly_from_file():
 	parser = argparse.ArgumentParser(description="Reports the polymorpgic rate of each reference (polymorphic bases / total bases). Focuses only on covered regions (i.e. depth >= 1)")
+	parser.add_argument('--version', action='version', version=f"CMSeq {__version__}")
+	
 	parser.add_argument('BAMFILE', help='The file on which to operate')
 	parser.add_argument('-c','--contig', help='Focus on a subset of references in the BAM file. Can be a list of references separated by commas or a FASTA file (the IDs are used to subset)', metavar="REFERENCE ID" ,default=None)
 	parser.add_argument('-f', help='If set unmapped (FUNMAP), secondary (FSECONDARY), qc-fail (FQCFAIL) and duplicate (FDUP) are excluded. If unset ALL reads are considered (bedtools genomecov style). Default: unset',action='store_true')

--- a/cmseq/polymut.py
+++ b/cmseq/polymut.py
@@ -2,12 +2,15 @@ import pandas as pd
 import numpy as np
 import argparse
 import sys
+from cmseq import __version__
 
 from .cmseq import CMSEQ_DEFAULTS
 from .cmseq import BamFile
 
 def polymut_from_file():
 	parser = argparse.ArgumentParser(description="Reports the polymorpgic rate of each reference (polymorphic bases / total bases). Focuses only on covered regions (i.e. depth >= 1)")
+	parser.add_argument('--version', action='version', version=f"CMSeq {__version__}")
+
 	parser.add_argument('BAMFILE', help='The file on which to operate')
 	parser.add_argument('-c','--contig', help='Focus on a subset of references in the BAM file. Can be a list of references separated by commas or a FASTA file (the IDs are used to subset)', metavar="REFERENCE ID" ,default=None)
 	parser.add_argument('-f', help='If set unmapped (FUNMAP), secondary (FSECONDARY), qc-fail (FQCFAIL) and duplicate (FDUP) are excluded. If unset ALL reads are considered (bedtools genomecov style). Default: unset',action='store_true')

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,27 @@
 import setuptools
+import codecs
 from setuptools.command.install import install
 from io import open
 import os
 
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), "r") as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
 install_requires = ["numpy", "scipy", "pysam", "pandas", "biopython", "bcbio-gff"]
 setuptools.setup(
     name='CMSeq',
-    version='1.0.4',
+    version=get_version("cmseq/__init__.py"),
     author='Moreno Zolfo',
     author_email='moreno.zolfo@unitn.it',
     url='http://github.com/SegataLab/cmseq/',


### PR DESCRIPTION
For better reproducibility, the user can now require the version of CMSeq directly from the command line using the `--version` flag for each subcommand.

Other changes:
- Add continuous integration test with 1607f0a ([flake8](https://flake8.pycqa.org/en/latest/) is commented out for now because it will make the tests fail, as you have an undefined variable `yminseq` [here](https://github.com/SegataLab/cmseq/blob/53690302f7e13e18ef573f5c1e6393bfd934741a/cmseq/cmseq.py#L258) )
- add a [`.gitignore`](https://git-scm.com/docs/gitignore) file
- Import from package directory instead of relative imports (example: `from cmseq.cmseq import BamFile` instead of `from .cmseq import BamFile`)

Once you merge, I can increase the build number on bioconda to make the changes available in bioconda withouth increasing the CMSeq version number